### PR TITLE
Fix seqnum too old issue with withdrawing

### DIFF
--- a/src/api/modules/aptos/index.ts
+++ b/src/api/modules/aptos/index.ts
@@ -611,6 +611,7 @@ export const getConfidentialBalances = async (
   tokenAddress = appConfig.PRIMARY_TOKEN_ADDRESS,
 ) => {
   const decryptionKey = new TwistedEd25519PrivateKey(decryptionKeyHex);
+  const publicKey = decryptionKey.publicKey();
 
   const { pending, actual } = await confidentialAssets.getBalance({
     accountAddress: account.accountAddress,
@@ -628,9 +629,14 @@ export const getConfidentialBalances = async (
       actual: confidentialAmountActual,
     };
   } catch (error) {
+    console.error('Failed to get confidential balances', error);
+    const pending = ConfidentialAmount.fromAmount(0n);
+    const actual = ConfidentialAmount.fromAmount(0n);
+    pending.encrypt(publicKey);
+    actual.encrypt(publicKey);
     return {
-      pending: ConfidentialAmount.fromAmount(0n),
-      actual: ConfidentialAmount.fromAmount(0n),
+      pending,
+      actual,
     };
   }
 };

--- a/src/app/dashboard/components/WithdrawForm.tsx
+++ b/src/app/dashboard/components/WithdrawForm.tsx
@@ -98,6 +98,17 @@ export default function WithdrawForm({
       handleSubmit(async formData => {
         disableForm();
 
+        const err = await ensureConfidentialBalanceReadyBeforeOp({
+          amountToEnsure: String(formData.amount),
+          token: token,
+          currentTokenStatus,
+        });
+        if (err) {
+          ErrorHandler.process(err);
+          enableForm();
+          return;
+        }
+
         const [withdrawTx, buildWithdrawError] = await tryCatch(
           buildWithdrawToTx(
             parseUnits(String(formData.amount), token.decimals).toString(),
@@ -109,17 +120,6 @@ export default function WithdrawForm({
         );
         if (buildWithdrawError) {
           ErrorHandler.process(buildWithdrawError);
-          enableForm();
-          return;
-        }
-
-        const err = await ensureConfidentialBalanceReadyBeforeOp({
-          amountToEnsure: String(formData.amount),
-          token: token,
-          currentTokenStatus,
-        });
-        if (err) {
-          ErrorHandler.process(err);
           enableForm();
           return;
         }

--- a/src/app/dashboard/context.tsx
+++ b/src/app/dashboard/context.tsx
@@ -912,7 +912,6 @@ export const ConfidentialCoinContextProvider = ({ children }: PropsWithChildren)
       amount: string,
       opts?: {
         auditorsEncryptionKeyHexList?: string[];
-
         isSyncFirst?: boolean;
       },
     ) => {
@@ -927,7 +926,6 @@ export const ConfidentialCoinContextProvider = ({ children }: PropsWithChildren)
               selectedAccountDecryptionKey.toString(),
               selectedToken.address,
             );
-
             return actual?.amountEncrypted;
           })()
         : selectedAccountDecryptionKeyStatusRaw.actual.amountEncrypted;


### PR DESCRIPTION
I also fix a bug related to encryptedAmount of ConfidentialBalance, see more here: https://www.notion.so/aptoslabs/Confidential-asset-notes-1dd8b846eb72804996fdf418f9d6e72e?pvs=4#1f98b846eb72803e9b40cf4c8efada4a. This is just a bandaid, I think the whole flow is maybe a bit sus.

I tested it as working with these two txns:
- https://explorer.aptoslabs.com/txn/0x6f4b60b3261c17eaca4e7a9c01b6479e11d1a7eff2f3f6f700ee7a0bda09dcce?network=testnet
- https://explorer.aptoslabs.com/txn/0xabb9882474e59b42f717942e8f9f96f08e8fa30beb8cff48e75cc50b03b37a19?network=testnet