### PR TITLE
Wait for indexer to catch up after minting

### DIFF
--- a/src/api/modules/aptos/index.ts
+++ b/src/api/modules/aptos/index.ts
@@ -8,6 +8,7 @@ import { RangeProofExecutor } from '@aptos-labs/confidential-assets';
 import {
   Account,
   AccountAddress,
+  AnyNumber,
   type CommittedTransactionResponse,
   Ed25519PrivateKey,
   EphemeralKeyPair,
@@ -579,10 +580,15 @@ export const getFAByCoinType = async (coinType: string): Promise<string> => {
   return fungibleAsset?.vec[0].inner;
 };
 
-export const getCoinBalanceByFaAddress = (account: Account, tokenAddress: string) => {
+export const getCoinBalanceByFaAddress = (
+  account: Account,
+  tokenAddress: string,
+  minimumLedgerVersion?: AnyNumber,
+) => {
   return aptos.account.getAccountCoinAmount({
     accountAddress: account.accountAddress,
     faMetadataAddress: tokenAddress,
+    minimumLedgerVersion,
   });
 };
 
@@ -596,10 +602,14 @@ export const getAptBalance = async (account: Account) => {
 };
 */
 
-export const getPrimaryTokenBalance = async (account: Account) => {
+export const getPrimaryTokenBalance = async (
+  account: Account,
+  minimumLedgerVersion?: AnyNumber,
+) => {
   const primaryTokenBalance = await aptos.getAccountCoinAmount({
     accountAddress: account.accountAddress,
     faMetadataAddress: appConfig.PRIMARY_TOKEN_ADDRESS,
+    minimumLedgerVersion,
   });
 
   return primaryTokenBalance;
@@ -706,7 +716,11 @@ export const getFungibleAssetMetadata = async (
   }));
 };
 
-export const getFABalance = async (account: Account, tokenAddressHex: string) => {
+export const getFABalance = async (
+  account: Account,
+  tokenAddressHex: string,
+  minimumLedgerVersion?: AnyNumber,
+) => {
   return aptos.fungibleAsset.getCurrentFungibleAssetBalances({
     options: {
       where: {
@@ -718,6 +732,9 @@ export const getFABalance = async (account: Account, tokenAddressHex: string) =>
         },
       },
     },
+    // We pass this to ensure that the indexer has synced up to the point where the
+    // changes we made have been indexed.
+    minimumLedgerVersion,
   });
 };
 

--- a/src/app/dashboard/components/ConfidentialAssetCard.tsx
+++ b/src/app/dashboard/components/ConfidentialAssetCard.tsx
@@ -45,8 +45,7 @@ export default function ConfidentialAssetCard({
   const {
     selectedAccount,
     registerAccountEncryptionKey,
-    reloadPrimaryTokenBalance,
-    loadSelectedDecryptionKeyState,
+    reloadBalances,
     perTokenStatuses,
   } = useConfidentialCoinContext();
   const gasStationArgs = useGasStationArgs();
@@ -82,10 +81,7 @@ export default function ConfidentialAssetCard({
 
     try {
       await registerAccountEncryptionKey(token.address);
-      await Promise.all([
-        loadSelectedDecryptionKeyState(),
-        reloadPrimaryTokenBalance(),
-      ]);
+      await reloadBalances();
     } catch (error) {
       if (+currTokenStatus.fungibleAssetBalance >= 0) {
         ErrorHandler.process(
@@ -105,21 +101,9 @@ export default function ConfidentialAssetCard({
         <div className='flex size-full flex-col items-center gap-4 rounded-2xl p-4'>
           <div className='relative flex items-center gap-2'>
             <Avatar name={token.address} size={20} variant='pixel' />
-
             <span className='typography-subtitle1 text-textPrimary'>
               {token.symbol} Balance
             </span>
-
-            {/* <button
-                  className='absolute left-full top-1/2 -translate-y-1/2'
-                  onClick={() => copy(token.address)}
-                >
-                  {isCopied ? (
-                    <Check size={24} className={'pl-2 text-textSecondary'} />
-                  ) : (
-                    <Copy size={24} className={'pl-2 text-textSecondary'} />
-                  )}
-                </button> */}
           </div>
 
           <div className='flex items-center'>

--- a/src/app/dashboard/components/DashboardHeader.tsx
+++ b/src/app/dashboard/components/DashboardHeader.tsx
@@ -494,7 +494,7 @@ function TransferNativeBottomSheet({
   onSubmit,
   ...rest
 }: TransferNativeBottomSheetProps) {
-  const { selectedAccount, primaryTokenBalance, reloadPrimaryTokenBalance } =
+  const { selectedAccount, primaryTokenBalance, reloadBalances } =
     useConfidentialCoinContext();
   const gasStationArgs = useGasStationArgs();
 
@@ -537,7 +537,7 @@ function TransferNativeBottomSheet({
             formData.amount,
             gasStationArgs,
           );
-          await reloadPrimaryTokenBalance();
+          await reloadBalances();
           onSubmit();
           clearForm();
         } catch (error) {
@@ -551,7 +551,7 @@ function TransferNativeBottomSheet({
       enableForm,
       handleSubmit,
       onSubmit,
-      reloadPrimaryTokenBalance,
+      reloadBalances,
       selectedAccount,
       gasStationArgs,
     ],

--- a/src/app/dashboard/components/Deposit/components/DepositMint.tsx
+++ b/src/app/dashboard/components/Deposit/components/DepositMint.tsx
@@ -1,4 +1,5 @@
 import { FixedNumber, parseUnits } from 'ethers';
+import { RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 
 import { getFABalance, mintPrimaryToken } from '@/api/modules/aptos';
@@ -158,7 +159,11 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
         return (
           <>
             <UiButton className='w-full' onClick={tryMint} disabled={isSubmitting}>
-              Get {MINT_AMOUNT} free {selectedToken?.symbol} tokens!
+              {isSubmitting ? (
+                <RefreshCw size={12} className='animate-spin' />
+              ) : (
+                `Get ${MINT_AMOUNT} free ${selectedToken?.symbol} tokens!`
+              )}
             </UiButton>
           </>
         );

--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -60,8 +60,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
     const {
       selectedAccount,
       buildTransferTx,
-      loadSelectedDecryptionKeyState,
-      reloadPrimaryTokenBalance,
+      reloadBalances,
       perTokenStatuses,
       ensureConfidentialBalanceReadyBeforeOp,
     } = useConfidentialCoinContext();
@@ -241,13 +240,10 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
             return;
           }
 
-          await sendAndWaitTx(transferTx, selectedAccount, gasStationArgs);
+          const res = await sendAndWaitTx(transferTx, selectedAccount, gasStationArgs);
 
           const [, reloadError] = await tryCatch(
-            Promise.all([
-              loadSelectedDecryptionKeyState(),
-              reloadPrimaryTokenBalance(),
-            ]),
+            Promise.all([reloadBalances(BigInt(res.version))]),
           );
           if (reloadError) {
             ErrorHandler.process(reloadError);
@@ -269,9 +265,8 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
         enableForm,
         ensureConfidentialBalanceReadyBeforeOp,
         handleSubmit,
-        loadSelectedDecryptionKeyState,
         onSubmit,
-        reloadPrimaryTokenBalance,
+        reloadBalances,
         resolvedAddress,
         isReceiverSelf,
         selectedAccount,

--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { formatUnits, isHexString, parseUnits } from 'ethers';
+import { RefreshCw } from 'lucide-react';
 import {
   ComponentProps,
   forwardRef,
@@ -82,6 +83,8 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
     const [debouncedUsername, setDebouncedUsername] = useState('');
     const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
     const [username, setUsername] = useState('');
+
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const formSchema = useForm(
       {
@@ -190,6 +193,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
           }
 
           disableForm();
+          setIsSubmitting(true);
 
           // Check if receiver has an encryption key
           const addressStr = resolvedAddress.toString();
@@ -199,6 +203,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
               new Error('Receiver not found or does not have an encryption key'),
             );
             enableForm();
+            setIsSubmitting(false);
             return;
           }
 
@@ -215,6 +220,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
           });
           if (err) {
             enableForm();
+            setIsSubmitting(false);
             return;
           }
 
@@ -231,6 +237,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
           if (buildTransferTxError) {
             ErrorHandler.process(buildTransferTxError);
             enableForm();
+            setIsSubmitting(false);
             return;
           }
 
@@ -245,12 +252,14 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
           if (reloadError) {
             ErrorHandler.process(reloadError);
             enableForm();
+            setIsSubmitting(false);
             return;
           }
 
           onSubmit();
           clearForm();
           enableForm();
+          setIsSubmitting(false);
         })(),
       [
         buildTransferTx,
@@ -352,7 +361,11 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
                   !resolvedAddress
                 }
               >
-                Send confidentially
+                {isSubmitting ? (
+                  <RefreshCw size={12} className='animate-spin' />
+                ) : (
+                  'Send confidentially'
+                )}
               </UiButton>
             </div>
           </div>

--- a/src/app/dashboard/components/WithdrawForm.tsx
+++ b/src/app/dashboard/components/WithdrawForm.tsx
@@ -27,8 +27,7 @@ export default function WithdrawForm({
     selectedToken,
     selectedAccount,
     buildWithdrawToTx,
-    loadSelectedDecryptionKeyState,
-    reloadPrimaryTokenBalance,
+    reloadBalances,
     perTokenStatuses,
     ensureConfidentialBalanceReadyBeforeOp,
   } = useConfidentialCoinContext();
@@ -129,7 +128,7 @@ export default function WithdrawForm({
           return;
         }
 
-        const [_txReceipt, withdrawError] = await tryCatch(
+        const [txReceipt, withdrawError] = await tryCatch(
           sendAndWaitTx(withdrawTx, selectedAccount, gasStationArgs),
         );
         if (withdrawError) {
@@ -140,7 +139,7 @@ export default function WithdrawForm({
         }
 
         const [, reloadError] = await tryCatch(
-          Promise.all([loadSelectedDecryptionKeyState(), reloadPrimaryTokenBalance()]),
+          reloadBalances(BigInt(txReceipt.version)),
         );
         if (reloadError) {
           ErrorHandler.process(reloadError);
@@ -162,9 +161,8 @@ export default function WithdrawForm({
       enableForm,
       ensureConfidentialBalanceReadyBeforeOp,
       handleSubmit,
-      loadSelectedDecryptionKeyState,
       onSubmit,
-      reloadPrimaryTokenBalance,
+      reloadBalances,
       selectedAccount,
       token,
       gasStationArgs,

--- a/src/app/dashboard/components/WithdrawForm.tsx
+++ b/src/app/dashboard/components/WithdrawForm.tsx
@@ -2,7 +2,8 @@
 
 import { AccountAddress } from '@aptos-labs/ts-sdk';
 import { formatUnits, parseUnits } from 'ethers';
-import { useCallback, useMemo } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { sendAndWaitTx } from '@/api/modules/aptos';
 import { aptos } from '@/api/modules/aptos/client';
@@ -44,6 +45,8 @@ export default function WithdrawForm({
   const totalBalanceBN = useMemo(() => {
     return publicBalanceBN + pendingAmountBN + actualAmountBN;
   }, [actualAmountBN, pendingAmountBN, publicBalanceBN]);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { isFormDisabled, handleSubmit, disableForm, enableForm, control, setValue } =
     useForm(
@@ -96,6 +99,7 @@ export default function WithdrawForm({
   const submit = useCallback(
     () =>
       handleSubmit(async formData => {
+        setIsSubmitting(true);
         disableForm();
 
         const err = await ensureConfidentialBalanceReadyBeforeOp({
@@ -106,6 +110,7 @@ export default function WithdrawForm({
         if (err) {
           ErrorHandler.process(err);
           enableForm();
+          setIsSubmitting(false);
           return;
         }
 
@@ -130,6 +135,7 @@ export default function WithdrawForm({
         if (withdrawError) {
           ErrorHandler.process(withdrawError);
           enableForm();
+          setIsSubmitting(false);
           return;
         }
 
@@ -139,12 +145,14 @@ export default function WithdrawForm({
         if (reloadError) {
           ErrorHandler.process(reloadError);
           enableForm();
+          setIsSubmitting(false);
           return;
         }
 
         onSubmit();
         clearForm();
         enableForm();
+        setIsSubmitting(false);
       })(),
     [
       buildWithdrawToTx,
@@ -190,7 +198,11 @@ export default function WithdrawForm({
       <div className='pt-4'>
         <UiSeparator className='mb-4' />
         <UiButton className='w-full' onClick={submit} disabled={isFormDisabled}>
-          Withdraw publicly
+          {isSubmitting ? (
+            <RefreshCw size={12} className='animate-spin' />
+          ) : (
+            'Withdraw publicly'
+          )}
         </UiButton>
       </div>
     </div>

--- a/src/app/dashboard/context.tsx
+++ b/src/app/dashboard/context.tsx
@@ -6,6 +6,7 @@ import {
 } from '@aptos-labs/confidential-assets';
 import {
   Account,
+  AnyNumber,
   CommittedTransactionResponse,
   InputGenerateTransactionPayloadData,
   KeylessAccount,
@@ -113,7 +114,7 @@ type ConfidentialCoinContextType = {
   // reloadAptBalance: () => Promise<void>;
 
   primaryTokenBalance: number;
-  reloadPrimaryTokenBalance: () => Promise<void>;
+  reloadPrimaryTokenBalance: (minimumLedgerVersion?: AnyNumber) => Promise<void>;
 
   tokens: TokenBaseInfo[];
   tokensLoadingState: LoadingState;
@@ -171,7 +172,7 @@ type ConfidentialCoinContextType = {
   // TODO: rotate keys
 
   decryptionKeyStatusLoadingState: LoadingState;
-  loadSelectedDecryptionKeyState: () => Promise<void>;
+  loadSelectedDecryptionKeyState: (minimumLedgerVersion?: AnyNumber) => Promise<void>;
 
   testMintTokens: (amount: string) => Promise<CommittedTransactionResponse[]>;
   ensureConfidentialBalanceReadyBeforeOp: (args: {
@@ -311,8 +312,8 @@ const useAccounts = () => {
     update,
   } = useLoading(
     0,
-    () => {
-      return getPrimaryTokenBalance(selectedAccount);
+    (minimumLedgerVersion?: AnyNumber) => {
+      return getPrimaryTokenBalance(selectedAccount, minimumLedgerVersion);
     },
     { loadArgs: [selectedAccount] },
   );
@@ -607,7 +608,7 @@ const useSelectedAccountDecryptionKeyStatus = (tokenAddress: string | undefined)
         ...AccountDecryptionKeyStatusRawDefault,
       },
     ],
-    async () => {
+    async (minimumLedgerVersion?: AnyNumber) => {
       if (!selectedAccount.accountAddress || !currentTokensList.length) {
         return [
           {
@@ -639,7 +640,7 @@ const useSelectedAccountDecryptionKeyStatus = (tokenAddress: string | undefined)
           const assetType = coin ? parseCoinTypeFromCoinStruct(coin) : el;
 
           const [fungibleAssetBalance, getFABalanceError] = await tryCatch(
-            getFABalance(selectedAccount, assetType),
+            getFABalance(selectedAccount, assetType, minimumLedgerVersion),
           );
           if (getFABalanceError) {
             return {
@@ -860,8 +861,8 @@ const useSelectedAccountDecryptionKeyStatus = (tokenAddress: string | undefined)
     selectedAccountDecryptionKeyStatus,
 
     decryptionKeyStatusLoadingState,
-    loadSelectedDecryptionKeyState: async () => {
-      await reload();
+    loadSelectedDecryptionKeyState: async (minimumLedgerVersion?: AnyNumber) => {
+      await reload(minimumLedgerVersion);
     },
 
     normalizeAccount,

--- a/src/hooks/loading.ts
+++ b/src/hooks/loading.ts
@@ -5,19 +5,19 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { ErrorHandler } from '@/helpers';
 
-type LoadingControl<T> = {
+type LoadingControl<T, A = void> = {
   data: T;
   isLoading: boolean;
   isLoadingError: boolean;
-  reload: () => Promise<void>;
+  reload: (args?: A) => Promise<void>;
   isEmpty: boolean;
-  update: () => Promise<void>;
+  update: (args?: A) => Promise<void>;
   reset: () => void;
 };
 
-export const useLoading = <T>(
+export const useLoading = <T, A = void>(
   initialState: T,
-  loadFn: () => Promise<T>,
+  loadFn: (args?: A) => Promise<T>,
   options?: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     loadArgs?: any[] | null;
@@ -25,7 +25,7 @@ export const useLoading = <T>(
     // in case if we need to paginate through all pages and concat in to one array
     loadAllPages?: boolean;
   },
-): LoadingControl<T> => {
+): LoadingControl<T, A> => {
   const { loadArgs, loadOnMount: _loadOnMount } = options ?? {};
   const loadOnMount = useMemo(() => _loadOnMount ?? true, [_loadOnMount]);
   const [isLoading, setIsLoading] = useState(loadOnMount);


### PR DESCRIPTION
## Stack
- Prev: #19
- Next: #21

<!--stack_end-->

## Summary
In this PR we confirm that the indexer (the core one, not our custom one for the confidential assets module) has caught up to the version of our txns after minting. I suspect the issue was essentially this:

1. Mint USDt at version 100
2. Veil USDt at version 200
3. Re-read state from indexer while it is up to version 150
4. Re-read state from node at version 250

So it would from the indexer API that there is 5 unveiled USDt and from the node API (via view function) that there is 5 veiled USDt.

By waiting for the indexer API to reach at least version 200 we avoid this problem. 

## Test Plan
So far just from manual testing it looks good, but we can roll it out and see if anyone else hits the issue.