### PR TITLE
Limit number of decimals when transferring / withdrawing

### DIFF
--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { formatUnits, isHexString, parseUnits } from 'ethers';
+import { isHexString, parseUnits } from 'ethers';
 import { RefreshCw } from 'lucide-react';
 import {
   ComponentProps,
@@ -15,7 +15,7 @@ import {
 
 import { getEkByAddr, sendAndWaitTx } from '@/api/modules/aptos';
 import { useConfidentialCoinContext } from '@/app/dashboard/context';
-import { ErrorHandler, isMobile, tryCatch } from '@/helpers';
+import { ErrorHandler, getYupAmountField, isMobile, tryCatch } from '@/helpers';
 import { useForm } from '@/hooks';
 import { useGetAnsSubdomainAddress } from '@/hooks/ans';
 import { useGasStationArgs } from '@/store/gas-station';
@@ -101,11 +101,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
               '',
               () => Boolean(resolvedAddress) || debouncedUsername === '',
             ),
-          amount: yup
-            .number()
-            .min(+formatUnits('1', token.decimals))
-            .max(totalBalanceBN ? +formatUnits(totalBalanceBN, token.decimals) : 0)
-            .required('Enter amount'),
+          amount: getYupAmountField(yup, token.decimals, totalBalanceBN),
           auditorsAddresses: yup.array().of(
             yup
               .string()

--- a/src/app/dashboard/components/WithdrawForm.tsx
+++ b/src/app/dashboard/components/WithdrawForm.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { AccountAddress } from '@aptos-labs/ts-sdk';
-import { formatUnits, parseUnits } from 'ethers';
+import { parseUnits } from 'ethers';
 import { RefreshCw } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { sendAndWaitTx } from '@/api/modules/aptos';
 import { aptos } from '@/api/modules/aptos/client';
 import { useConfidentialCoinContext } from '@/app/dashboard/context';
-import { ErrorHandler, tryCatch } from '@/helpers';
+import { ErrorHandler, getYupAmountField, tryCatch } from '@/helpers';
 import { useForm } from '@/hooks';
 import { useGasStationArgs } from '@/store/gas-station';
 import { TokenBaseInfo } from '@/store/wallet';
@@ -83,11 +83,7 @@ export default function WithdrawForm({
                 selectedAccount.accountAddress.toString().toLowerCase()
               );
             }),
-          amount: yup
-            .number()
-            .min(+formatUnits('1', token.decimals))
-            .max(totalBalanceBN ? +formatUnits(totalBalanceBN, token.decimals) : 0)
-            .required('Enter amount'),
+          amount: getYupAmountField(yup, token.decimals, totalBalanceBN),
         }),
     );
 
@@ -175,12 +171,14 @@ export default function WithdrawForm({
         <ControlledUiInput
           control={control}
           name='recipient'
-          placeholder='Enter recipient address'
+          label='Recipient Address / ANS Name'
+          placeholder='Enter recipient address / ANS name'
           disabled={isFormDisabled}
         />
         <ControlledUiInput
           control={control}
           name='amount'
+          label={`Amount (${token.symbol})`}
           placeholder='Enter amount'
           disabled={isFormDisabled}
         />
@@ -190,7 +188,9 @@ export default function WithdrawForm({
         <h4 className='font-semibold text-textPrimary'>
           Withdraw {selectedToken?.symbol} to public account
         </h4>
-        <p className='text-sm text-textSecondary'>By sending to the address.</p>
+        <p className='text-sm text-textSecondary'>
+          By sending to an address or ANS name.
+        </p>
       </div>
 
       <div className='pt-4'>

--- a/src/helpers/form.ts
+++ b/src/helpers/form.ts
@@ -1,0 +1,29 @@
+import { formatUnits } from 'ethers';
+import * as Yup from 'yup';
+
+/**
+ * Common helper to get a yup schema for an amount field.
+ */
+export function getYupAmountField(
+  yup: typeof Yup,
+  decimals: number,
+  totalBalanceBN: bigint,
+) {
+  return yup
+    .number()
+    .min(+formatUnits('1', decimals))
+    .max(totalBalanceBN ? +formatUnits(totalBalanceBN, decimals) : 0)
+    .test(
+      'maxDecimals',
+      `Amount cannot have more than ${decimals} decimal places`,
+      value => {
+        if (value === undefined || value === null) return true;
+        const valueStr = value.toString();
+        const decimalIndex = valueStr.indexOf('.');
+        if (decimalIndex === -1) return true;
+        const decimalPlaces = valueStr.length - decimalIndex - 1;
+        return decimalPlaces <= decimals;
+      },
+    )
+    .required('Enter amount');
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,6 +2,7 @@ export * from './clipboard';
 export * from './device';
 export * from './error-handler';
 export * from './event-bus';
+export * from './form';
 export * from './formatters';
 export * from './promise';
 export * from './router';


### PR DESCRIPTION
## Summary
There was an issue where the user could input numbers with any number of decimals, but that isn't valid because the FA in question has a particular maximum number of decimals you can use (e.g. OCTAs for APT).

## Test Plan
Tested by hand with a variety of inputs.