### PR TITLE
Support withdrawing to ANS name, improve validation

### DIFF
--- a/src/app/dashboard/components/ActivitiesFeed.tsx
+++ b/src/app/dashboard/components/ActivitiesFeed.tsx
@@ -14,6 +14,7 @@ import { HTMLAttributes, useCallback, useEffect, useRef, useState } from 'react'
 import { getTxExplorerUrl } from '@/api/modules/aptos';
 import { noCodeClient } from '@/api/modules/aptos/client';
 import { appConfig } from '@/config';
+import { trimAddress } from '@/helpers';
 import { useDecryptedAmount } from '@/hooks/amount-decryption';
 import { useGetAnsPrimaryName } from '@/hooks/ans';
 import { cn } from '@/theme/utils';
@@ -594,10 +595,3 @@ const formatAmount = (amount: number, symbol: string, decimals: number) => {
   const properAmount = amount / 10 ** decimals;
   return `${properAmount.toLocaleString()} ${symbol}`;
 };
-
-function trimAddress(address: string): string {
-  if (address.length < 4) {
-    return address;
-  }
-  return address.slice(0, 6) + '...' + address.slice(-6);
-}

--- a/src/helpers/form.ts
+++ b/src/helpers/form.ts
@@ -15,7 +15,7 @@ export function getYupAmountField(
     .max(totalBalanceBN ? +formatUnits(totalBalanceBN, decimals) : 0)
     .test(
       'maxDecimals',
-      `Amount cannot have more than ${decimals} decimal places`,
+      `Amount cannot have more than ${decimals} decimal places.`,
       value => {
         if (value === undefined || value === null) return true;
         const valueStr = value.toString();

--- a/src/helpers/formatters.ts
+++ b/src/helpers/formatters.ts
@@ -153,3 +153,10 @@ export function formatBalance(
 export function abbrCenter(addr: string, start = 4, end = 4) {
   return `${addr.slice(0, start)}...${addr.slice(-end)}`;
 }
+
+export function trimAddress(address: string): string {
+  if (address.length < 4) {
+    return address;
+  }
+  return address.slice(0, 6) + '...' + address.slice(-6);
+}

--- a/src/hooks/ans.ts
+++ b/src/hooks/ans.ts
@@ -145,3 +145,22 @@ export function useGetAnsPrimaryName({
     enabled,
   });
 }
+
+export function useGetTargetAddress({
+  name,
+  enabled = true,
+}: {
+  name: string;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: ['ansTargetAddress', name],
+    queryFn: async () => {
+      const out = await aptos.ans.getTargetAddress({
+        name,
+      });
+      return out ?? null;
+    },
+    enabled,
+  });
+}

--- a/src/hooks/form.ts
+++ b/src/hooks/form.ts
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type {
   Control,
   DefaultValues,
@@ -10,6 +10,7 @@ import type {
   UseFormRegister,
   UseFormSetError,
   UseFormSetValue,
+  UseFormTrigger,
 } from 'react-hook-form';
 import { useForm as useFormHook } from 'react-hook-form';
 import * as Yup from 'yup';
@@ -26,6 +27,8 @@ export type Form<T extends FieldValues> = {
   setError: UseFormSetError<T>;
   setValue: UseFormSetValue<T>;
   control: Control<T>;
+  canSubmitForm: boolean;
+  trigger: UseFormTrigger<T>;
 };
 
 export const useForm = <T extends Yup.AnyObjectSchema, R extends FieldValues>(
@@ -41,14 +44,15 @@ export const useForm = <T extends Yup.AnyObjectSchema, R extends FieldValues>(
     watch,
     setError,
     setValue,
-    formState: { errors },
+    trigger,
+    formState: { errors, isValid },
   } = useFormHook<R>({
     mode: 'onTouched',
     reValidateMode: 'onChange',
     criteriaMode: 'firstError',
     shouldUseNativeValidation: false,
     defaultValues: defaultValues as DefaultValues<R>,
-    resolver: yupResolver(schemaBuilder(Yup)),
+    resolver: yupResolver(schemaBuilder(Yup), { abortEarly: false }),
   });
 
   const getErrorMessage = (fieldName: FieldPath<R>): string => {
@@ -63,6 +67,10 @@ export const useForm = <T extends Yup.AnyObjectSchema, R extends FieldValues>(
     setIsFormDisabled(false);
   };
 
+  const canSubmitForm = useMemo(() => {
+    return isValid && !isFormDisabled;
+  }, [isValid, isFormDisabled]);
+
   return {
     isFormDisabled,
     getErrorMessage,
@@ -75,5 +83,7 @@ export const useForm = <T extends Yup.AnyObjectSchema, R extends FieldValues>(
     setError,
     setValue,
     control,
+    canSubmitForm,
+    trigger,
   };
 };

--- a/src/ui/UiInput.tsx
+++ b/src/ui/UiInput.tsx
@@ -56,10 +56,14 @@ function ControlledUiInput<T extends FieldValues>({
           rest.onChange?.(e);
           field.onChange(e);
         }}
+        onBlur={e => {
+          rest.onBlur?.(e);
+          field.onBlur();
+        }}
         value={field.value}
       />
       {fieldState.error?.message && (
-        <span className='typography-caption3 text-errorMain'>
+        <span className='typography-caption1 text-warningMain'>
           {fieldState.error.message}
         </span>
       )}


### PR DESCRIPTION
## Summary
This PR does a few main things:
1. Adds support for withdrawing to ANS names.
2. Improves validation of the recipient when withdrawing to an address.
3. Moves all the validation logic in TransferFormSheet to the yup schema.
4. Improves the appearance of validation warnings.

## Test Plan
I tested withdrawing to an address an ANS name, a variety of invalid input, etc. Transferring still works too.