### PR TITLE
Recipient veiling requirement

### DIFF
--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -112,7 +112,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
             })
             .test(
               'hasEncryptionKey',
-              "Recipient can't receive confidential transfers until they veil APT.",
+              "Recipient can't receive confidential transfers until they veil some APT at least once.",
               async () => {
                 if (!resolvedAddress) return true;
 

--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -112,7 +112,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
             })
             .test(
               'hasEncryptionKey',
-              'Receiver does not have an encryption key.',
+              "Recipient can't receive confidential transfers until they veil APT.",
               async () => {
                 if (!resolvedAddress) return true;
 


### PR DESCRIPTION
Update confidential transfer error message to clarify why a recipient cannot receive funds.

---
[Slack Thread](https://aptos-org.slack.com/archives/C0A8R4USZBQ/p1770261836230699?thread_ts=1770261836.230699&cid=C0A8R4USZBQ)

<p><a href="https://cursor.com/background-agent?bcId=bc-aeb4bf17-40a3-539a-9760-93c44b50a678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aeb4bf17-40a3-539a-9760-93c44b50a678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

