### PR TITLE
Add network picker, conditional faucet/deposit, and flexible recipient resolution

### DIFF
--- a/src/api/modules/aptos/client.ts
+++ b/src/api/modules/aptos/client.ts
@@ -24,10 +24,16 @@ export const confidentialAsset = new ConfidentialAsset({
   withFeePayer: true,
 });
 
+export const isTestnet = () => appConfig.APTOS_NETWORK === 'testnet';
+
+const NOCODE_URLS: Record<string, string> = {
+  testnet:
+    'https://api.testnet.staging.aptoslabs.com/nocode/v1/api/cmacir19c0009s601tnchf781/v1/graphql',
+  mainnet:
+    'https://api.mainnet.aptoslabs.com/nocode/v1/api/cmacir19c0009s601tnchf781/v1/graphql',
+};
+
 /** Do not forget to pass the API key when using this client. */
 export const noCodeClient = getSdk(
-  new GraphQLClient(
-    // TODO: Make this configurable.
-    'https://api.testnet.staging.aptoslabs.com/nocode/v1/api/cmacir19c0009s601tnchf781/v1/graphql',
-  ),
+  new GraphQLClient(NOCODE_URLS[appConfig.APTOS_NETWORK] || NOCODE_URLS.testnet),
 );

--- a/src/app/dashboard/client.tsx
+++ b/src/app/dashboard/client.tsx
@@ -10,9 +10,12 @@ import {
 } from 'react';
 import { useMeasure } from 'react-use';
 
+import { isTestnet } from '@/api/modules/aptos/client';
 import AddTokenForm from '@/app/dashboard/components/AddTokenForm';
 import ConfidentialAssetCard from '@/app/dashboard/components/ConfidentialAssetCard';
 import DashboardHeader from '@/app/dashboard/components/DashboardHeader';
+import DepositAddress from '@/app/dashboard/components/DepositAddress';
+import NetworkPicker from '@/app/dashboard/components/NetworkPicker';
 import TokenInfo from '@/app/dashboard/components/TokenInfo';
 import WithdrawForm from '@/app/dashboard/components/WithdrawForm';
 import { useConfidentialCoinContext } from '@/app/dashboard/context';
@@ -158,7 +161,8 @@ export default function DashboardClient() {
 
   return (
     <div className='flex size-full flex-col'>
-      <header className='order-2 flex h-16 shrink-0 items-center justify-end gap-2 px-4 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 md:order-1'>
+      <header className='order-2 flex h-16 shrink-0 items-center justify-between gap-2 px-4 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 md:order-1'>
+        <NetworkPicker />
         <DashboardHeader />
       </header>
       <div className='order-1 flex flex-1 flex-col overflow-y-auto md:order-2'>
@@ -248,16 +252,29 @@ export default function DashboardClient() {
           </div>
 
           <div className='flex w-full flex-row items-center justify-center gap-8 self-center px-4 md:max-w-[50%]'>
-            <CircleButton
-              className='flex-1'
-              caption={'Faucet'}
-              iconProps={{
-                name: 'CircleDollarSignIcon',
-              }}
-              onClick={() => {
-                setIsDepositSheetOpen(true);
-              }}
-            />
+            {isTestnet() ? (
+              <CircleButton
+                className='flex-1'
+                caption={'Faucet'}
+                iconProps={{
+                  name: 'CircleDollarSignIcon',
+                }}
+                onClick={() => {
+                  setIsDepositSheetOpen(true);
+                }}
+              />
+            ) : (
+              <CircleButton
+                className='flex-1'
+                caption={'Deposit'}
+                iconProps={{
+                  name: 'CircleDollarSignIcon',
+                }}
+                onClick={() => {
+                  setIsDepositSheetOpen(true);
+                }}
+              />
+            )}
 
             {/* <CircleButton
             caption={'Token Info'}
@@ -332,16 +349,20 @@ export default function DashboardClient() {
                   size={18}
                   className='text-textPrimary'
                 />
-                Deposit {selectedToken.name}
+                {isTestnet() ? `Deposit ${selectedToken.name}` : 'Deposit'}
               </UiSheetTitle>
             </UiSheetHeader>
             <UiSeparator className='mb-4 mt-2' />
-            <Deposit
-              onSubmit={() => {
-                setIsDepositSheetOpen(false);
-                tryRefresh();
-              }}
-            />
+            {isTestnet() ? (
+              <Deposit
+                onSubmit={() => {
+                  setIsDepositSheetOpen(false);
+                  tryRefresh();
+                }}
+              />
+            ) : (
+              <DepositAddress />
+            )}
           </UiSheetContent>
         </UiSheet>
         <UiSheet open={isTokenInfoSheetOpen} onOpenChange={setIsTokenInfoSheetOpen}>

--- a/src/app/dashboard/components/DepositAddress.tsx
+++ b/src/app/dashboard/components/DepositAddress.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { CheckIcon, CopyIcon } from 'lucide-react';
+
+import { useConfidentialCoinContext } from '@/app/dashboard/context';
+import { appConfig } from '@/config';
+import { abbrCenter } from '@/helpers';
+import { useCopyToClipboard } from '@/hooks';
+import { useGetAnsSubdomains } from '@/hooks/ans';
+import { UiSeparator } from '@/ui/UiSeparator';
+
+export default function DepositAddress() {
+  const { selectedAccount } = useConfidentialCoinContext();
+  const addressHex = selectedAccount.accountAddress.toString();
+
+  const { data: ansNameData } = useGetAnsSubdomains({
+    accountAddress: selectedAccount.accountAddress,
+    enabled: true,
+  });
+
+  const subdomain = ansNameData?.subdomain;
+  const ansFullName = subdomain ? `${subdomain}.${appConfig.ANS_DOMAIN}.apt` : null;
+
+  const addressCopy = useCopyToClipboard();
+  const ansCopy = useCopyToClipboard();
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <p className='text-sm text-textSecondary'>
+        Send funds to either your ANS name or public address below. Funds will be
+        automatically veiled once received.
+      </p>
+
+      {ansFullName && (
+        <div className='rounded-xl bg-componentPrimary p-4'>
+          <div className='mb-1 text-xs uppercase text-textSecondary'>ANS Name</div>
+          <button
+            className='flex w-full items-center justify-between gap-2'
+            onClick={() => ansCopy.copy(ansFullName)}
+          >
+            <span className='typography-subtitle4 break-all text-textPrimary'>
+              {ansFullName}
+            </span>
+            {ansCopy.isCopied ? (
+              <CheckIcon className='size-4 shrink-0 text-successMain' />
+            ) : (
+              <CopyIcon className='size-4 shrink-0 text-textSecondary' />
+            )}
+          </button>
+        </div>
+      )}
+
+      <UiSeparator />
+
+      <div className='rounded-xl bg-componentPrimary p-4'>
+        <div className='mb-1 text-xs uppercase text-textSecondary'>Public Address</div>
+        <button
+          className='flex w-full items-center justify-between gap-2'
+          onClick={() => addressCopy.copy(addressHex)}
+        >
+          <span className='typography-caption1 break-all text-textPrimary'>
+            {abbrCenter(addressHex, 16)}
+          </span>
+          {addressCopy.isCopied ? (
+            <CheckIcon className='size-4 shrink-0 text-successMain' />
+          ) : (
+            <CopyIcon className='size-4 shrink-0 text-textSecondary' />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/components/NetworkPicker.tsx
+++ b/src/app/dashboard/components/NetworkPicker.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Network } from '@aptos-labs/ts-sdk';
+
+import { useNetworkStore } from '@/store/network';
+import { cn } from '@/theme/utils';
+
+const NETWORKS = [
+  { value: Network.MAINNET, label: 'Mainnet' },
+  { value: Network.TESTNET, label: 'Testnet' },
+] as const;
+
+export default function NetworkPicker() {
+  const { selectedNetwork, setSelectedNetwork } = useNetworkStore();
+
+  return (
+    <div className='flex items-center rounded-full bg-componentPrimary p-0.5'>
+      {NETWORKS.map(({ value, label }) => (
+        <button
+          key={value}
+          onClick={() => {
+            if (value !== selectedNetwork) {
+              setSelectedNetwork(value);
+            }
+          }}
+          className={cn(
+            'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+            value === selectedNetwork
+              ? 'bg-primary text-primary-foreground'
+              : 'text-textSecondary hover:text-textPrimary',
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -15,9 +15,10 @@ import {
 
 import { getEncryptionKey } from '@/api/modules/aptos';
 import { useConfidentialCoinContext } from '@/app/dashboard/context';
+import { appConfig } from '@/config';
 import { ErrorHandler, getYupAmountField, isMobile, tryCatch } from '@/helpers';
 import { useForm } from '@/hooks';
-import { useGetAnsSubdomainAddress } from '@/hooks/ans';
+import { useResolveRecipient } from '@/hooks/ans';
 import { TokenBaseInfo } from '@/store/wallet';
 import { UiButton } from '@/ui/UiButton';
 import { ControlledUiInput } from '@/ui/UiInput';
@@ -93,12 +94,11 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
         yup.object().shape({
           receiverUsername: yup
             .string()
-            .required('Enter receiver username')
+            .required('Enter recipient')
             .test(
-              'usernameExists',
-              'Username not found. Please check and try again.',
+              'recipientExists',
+              'Recipient not found. Please check and try again.',
               () => {
-                // Only validate if we have a debounced username and it's not currently loading
                 if (debouncedUsername === '' || isResolvingAddress) return true;
                 return Boolean(resolvedAddress);
               },
@@ -181,10 +181,10 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
       };
     }, [username]);
 
-    // Query ANS to resolve username to address
+    // Resolve recipient: supports bare usernames (autocomplete .veiled.apt), full ANS names, and hex addresses
     const { data: resolvedAddress, isLoading: isResolvingAddress } =
-      useGetAnsSubdomainAddress({
-        subdomain: debouncedUsername.replace('@', ''),
+      useResolveRecipient({
+        input: debouncedUsername,
         enabled: debouncedUsername !== '',
       });
 
@@ -316,10 +316,14 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
                 <ControlledUiInput
                   control={control}
                   name='receiverUsername'
-                  label='Recipient Username'
-                  placeholder='Enter recipient username'
+                  label='Recipient'
+                  placeholder={`username, name.apt, or 0x address`}
                 />
-                <div className='pb-2' />
+                <div className='pb-1 text-xs text-textSecondary'>
+                  Bare usernames resolve to{' '}
+                  <span className='font-medium'>.{appConfig.ANS_DOMAIN}.apt</span>
+                </div>
+                <div className='pb-1' />
                 {resolvedAddress &&
                   debouncedUsername !== '' &&
                   !isResolvingAddress &&

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,12 +59,26 @@ export const ASSET_CONFIG = {
   },
 } as const;
 
+export const getStoredNetwork = (): string => {
+  if (typeof window === 'undefined') return 'mainnet';
+  try {
+    const stored = localStorage.getItem('network-store');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return parsed?.state?.selectedNetwork ?? 'mainnet';
+    }
+  } catch {
+    // ignore
+  }
+  return 'mainnet';
+};
+
 export const appConfig: AppConfig = {
   CONFIDENTIAL_ASSET_MODULE_ADDR:
     process.env.NEXT_PUBLIC_CONFIDENTIAL_ASSET_MODULE_ADDR!,
   // Derive PRIMARY_TOKEN_ADDRESS from the selected asset.
   PRIMARY_TOKEN_ADDRESS: ASSET_CONFIG[PRIMARY_ASSET].address,
-  APTOS_NETWORK: 'testnet',
+  APTOS_NETWORK: getStoredNetwork(),
 
   SUBDOMAIN_MANAGER_CONTRACT_ADDR:
     process.env.NEXT_PUBLIC_SUBDOMAIN_MANAGER_CONTRACT_ADDR!,

--- a/src/hooks/ans.ts
+++ b/src/hooks/ans.ts
@@ -164,3 +164,45 @@ export function useGetTargetAddress({
     enabled,
   });
 }
+
+/**
+ * Resolves a recipient input which can be:
+ * 1. A hex address (0x...)
+ * 2. A bare username (resolved as username.{ANS_DOMAIN})
+ * 3. A full ANS name (e.g. username.apt, subdomain.domain.apt)
+ */
+export function useResolveRecipient({
+  input,
+  enabled = true,
+}: {
+  input: string;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: ['resolveRecipient', input],
+    queryFn: async (): Promise<AccountAddress | null> => {
+      const trimmed = input.trim().replace(/^@/, '');
+      if (!trimmed) return null;
+
+      if (trimmed.startsWith('0x')) {
+        try {
+          return AccountAddress.from(trimmed);
+        } catch {
+          return null;
+        }
+      }
+
+      if (trimmed.endsWith('.apt') || trimmed.includes('.')) {
+        const name = trimmed.endsWith('.apt') ? trimmed : `${trimmed}.apt`;
+        const out = await aptos.ans.getTargetAddress({ name });
+        return out ?? null;
+      }
+
+      const out = await aptos.ans.getTargetAddress({
+        name: `${trimmed}.${appConfig.ANS_DOMAIN}`,
+      });
+      return out ?? null;
+    },
+    enabled: enabled && input.trim().length > 0,
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,9 +15,14 @@ async function shouldShowMaintenancePage() {
     return true;
   }
 
+  const apiBase =
+    appConfig.APTOS_NETWORK === 'mainnet'
+      ? 'https://api.mainnet.aptoslabs.com/v1'
+      : 'https://api.testnet.aptoslabs.com/v1';
+
   try {
     const response = await fetch(
-      `https://api.testnet.aptoslabs.com/v1/accounts/${appConfig.CONFIDENTIAL_ASSET_MODULE_ADDR}/module/confidential_asset`,
+      `${apiBase}/accounts/${appConfig.CONFIDENTIAL_ASSET_MODULE_ADDR}/module/confidential_asset`,
       {
         headers: {
           Authorization: `Bearer ${appConfig.APTOS_BUILD_API_KEY}`,

--- a/src/store/network.ts
+++ b/src/store/network.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { Network } from '@aptos-labs/ts-sdk';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+type NetworkState = {
+  selectedNetwork: Network;
+  _hasHydrated: boolean;
+};
+
+type NetworkActions = {
+  setSelectedNetwork: (network: Network) => void;
+  setHasHydrated: (value: boolean) => void;
+};
+
+export const useNetworkStore = create<NetworkState & NetworkActions>()(
+  persist(
+    set => ({
+      selectedNetwork: Network.MAINNET,
+      _hasHydrated: false,
+
+      setSelectedNetwork: (network: Network) => {
+        set({ selectedNetwork: network });
+        window.location.reload();
+      },
+      setHasHydrated: (value: boolean) => {
+        set({ _hasHydrated: value });
+      },
+    }),
+    {
+      storage: createJSONStorage(() => localStorage),
+      name: 'network-store',
+      version: 1,
+      onRehydrateStorage: () => state => {
+        state?.setHasHydrated(true);
+      },
+    },
+  ),
+);
+
+export const getSelectedNetwork = (): Network => {
+  try {
+    const stored = localStorage.getItem('network-store');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return parsed?.state?.selectedNetwork ?? Network.MAINNET;
+    }
+  } catch {
+    // ignore
+  }
+  return Network.MAINNET;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a network picker to switch between **mainnet** (default) and **testnet**, conditionally shows faucet vs deposit functionality, and updates the "Send Confidentially" flow to accept any username, ANS name, or hex address.

## Changes

### Network Picker
- New `NetworkPicker` component rendered in the dashboard header with a pill-style toggle between Mainnet and Testnet
- Network selection persisted to localStorage via a Zustand store (`network-store`) with **mainnet as the default**
- Switching networks triggers a page reload to reinitialize the Aptos client with the correct network configuration

### Conditional Faucet / Deposit
- **Testnet**: Shows the existing "Faucet" button that opens the faucet sheet (unchanged behavior)
- **Mainnet**: Shows a "Deposit" button that opens a sheet displaying:
  - The user's ANS name (e.g. `username.veiled.apt`) with a copy button
  - The user's public hex address with a copy button
  - A message explaining that deposited funds will be auto-veiled

### Flexible Recipient Resolution (Send Confidentially)
The recipient input field now supports three formats:
1. **Bare usernames** (e.g. `alice`) — auto-resolved as `alice.veiled.apt` (using the configured ANS domain)
2. **Full ANS names** (e.g. `alice.apt`, `sub.domain.apt`) — resolved directly via ANS
3. **Hex addresses** (e.g. `0x1234...`) — used directly as the recipient address

A new `useResolveRecipient` hook handles all three cases with a single debounced query.

### Infrastructure Updates
- `config.ts`: Reads network from localStorage (SSR-safe with mainnet fallback)
- `client.ts`: Aptos client, Confidential Asset client, gas station, and NoCode GraphQL URL all use the dynamic network
- `middleware.ts`: Module health check URL is now network-aware

## Files Changed
- `src/store/network.ts` — new network store
- `src/app/dashboard/components/NetworkPicker.tsx` — new network picker component
- `src/app/dashboard/components/DepositAddress.tsx` — new mainnet deposit component
- `src/app/dashboard/client.tsx` — conditional UI, header layout
- `src/app/dashboard/components/TransferFormSheet.tsx` — flexible recipient input
- `src/hooks/ans.ts` — new `useResolveRecipient` hook
- `src/config.ts` — dynamic network from localStorage
- `src/api/modules/aptos/client.ts` — dynamic client config, `isTestnet()` helper
- `src/middleware.ts` — network-aware health check
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/D0ALLE1EQU9/p1777067166319469?thread_ts=1777067166.319469&cid=D0ALLE1EQU9)

<div><a href="https://cursor.com/agents/bc-2e947302-ce2e-5b69-ba3a-3f97558661cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e947302-ce2e-5b69-ba3a-3f97558661cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

