### PR TITLE
feat: add terms of use and privacy policy links to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,26 @@ export default async function RootPage() {
         <HomepageLink />
       </div>
 
+      <div className='absolute bottom-4 left-4 z-20 flex gap-4'>
+        <a
+          href='https://aptoslabs.com/terms-wallet'
+          target='_blank'
+          rel='noopener noreferrer'
+          className='typography-caption1 text-textSecondary transition-colors hover:text-textPrimary'
+        >
+          Terms of Use
+        </a>
+
+        <a
+          href='https://aptoslabs.com/privacy'
+          target='_blank'
+          rel='noopener noreferrer'
+          className='typography-caption1 text-textSecondary transition-colors hover:text-textPrimary'
+        >
+          Privacy Policy
+        </a>
+      </div>
+
       <div className='background-gradient absolute -bottom-[20%] -right-[20%] h-[70dvh] w-[75vw] rotate-[70deg] rounded-[50%] opacity-80 blur-[70px]' />
 
       <div


### PR DESCRIPTION
## Summary
- Add **Terms of Use** and **Privacy Policy** links to the bottom left of the homepage
- Terms links to https://aptoslabs.com/terms-wallet
- Privacy links to https://aptoslabs.com/privacy

## Details
- Both links open in a new tab (`target="_blank"` + `rel="noopener noreferrer"`)
- Styled with `text-textSecondary` and a hover transition to `text-textPrimary` to match existing theme tokens
- Positioned at `bottom-4 left-4` with `z-20` so they sit above the background gradient/mask layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)