### PR TITLE
fix: replace Mint with Deposit in activity feed

### DIFF
--- a/src/app/dashboard/components/ActivitiesFeed.tsx
+++ b/src/app/dashboard/components/ActivitiesFeed.tsx
@@ -399,7 +399,7 @@ function TxItem({
       <ArrowDownIcon size={18} className='text-textPrimary' />
     );
   } else if (activityType === 'deposit') {
-    title = isSelfDeposit ? 'Mint' : 'Deposit';
+    title = 'Deposit';
     icon = isSelfDeposit ? (
       <DollarSignIcon size={18} className='text-textPrimary' />
     ) : (


### PR DESCRIPTION
Replace 'Mint' label with 'Deposit' in the activity feed for self-deposit transactions.