### PR TITLE
Rename "veil" terminology to "convert to confidential APT"

### DIFF
--- a/src/app/dashboard/components/Deposit/components/DepositAddress.tsx
+++ b/src/app/dashboard/components/Deposit/components/DepositAddress.tsx
@@ -149,8 +149,8 @@ export default function DepositAddress() {
   return (
     <div className='flex w-full flex-col gap-3'>
       <p className='typography-body2 text-textSecondary'>
-        Send funds to this address to deposit. They will be converted to confidential APT
-        automatically once they arrive.
+        Send funds to this address to deposit. They will be converted to confidential
+        APT automatically once they arrive.
       </p>
       {username && <CopyRow label='Username' value={username} />}
       <CopyRow label='Address' value={address} />

--- a/src/app/dashboard/components/Deposit/components/DepositAddress.tsx
+++ b/src/app/dashboard/components/Deposit/components/DepositAddress.tsx
@@ -13,7 +13,7 @@ import { abbrCenter, bus, BusEvents, ErrorHandler, sleep, tryCatch } from '@/hel
 import { useCopyToClipboard } from '@/hooks';
 import { useGetAnsSubdomains } from '@/hooks/ans';
 
-type VeilState = 'waiting' | 'veiling' | 'veiled';
+type ConvertState = 'waiting' | 'converting' | 'converted';
 
 function CopyRow({ label, value }: { label: string; value: string }) {
   const { copy, isCopied } = useCopyToClipboard();
@@ -47,14 +47,14 @@ export default function DepositAddress() {
   const subdomain = ansNameData?.subdomain;
   const username = subdomain ? `${subdomain}.${appConfig.ANS_DOMAIN}.apt` : null;
 
-  const [veilState, setVeilState] = useState<VeilState>('waiting');
+  const [convertState, setConvertState] = useState<ConvertState>('waiting');
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const initialBalanceRef = useRef<bigint | null>(null);
 
-  const doVeil = useCallback(
+  const doConvert = useCallback(
     async (amountToDeposit: bigint) => {
       if (!selectedToken || !selectedAccount) return;
-      setVeilState('veiling');
+      setConvertState('converting');
 
       const [coin] = await tryCatch(getCoinByFaAddress(selectedToken.address));
 
@@ -69,7 +69,7 @@ export default function DepositAddress() {
           attempts += 1;
           if (attempts >= 5) {
             ErrorHandler.process(err);
-            setVeilState('waiting');
+            setConvertState('waiting');
             return;
           }
           await sleep(200);
@@ -79,7 +79,7 @@ export default function DepositAddress() {
         const [, reloadErr] = await tryCatch(reloadBalances(BigInt(receipt.version)));
         if (reloadErr) {
           ErrorHandler.process(reloadErr);
-          setVeilState('waiting');
+          setConvertState('waiting');
           return;
         }
 
@@ -88,9 +88,9 @@ export default function DepositAddress() {
         ).toFixed(2);
         bus.emit(
           BusEvents.Success,
-          `Successfully veiled deposit of ${formatted} ${selectedToken.symbol}`,
+          `Successfully converted ${formatted} ${selectedToken.symbol} to confidential APT`,
         );
-        setVeilState('veiled');
+        setConvertState('converted');
         return;
       }
     },
@@ -125,7 +125,7 @@ export default function DepositAddress() {
             clearInterval(pollingRef.current);
             pollingRef.current = null;
           }
-          await doVeil(current);
+          await doConvert(current);
         }
       }, 400);
     })();
@@ -137,20 +137,20 @@ export default function DepositAddress() {
         pollingRef.current = null;
       }
     };
-  }, [doVeil, selectedAccount, selectedToken]);
+  }, [doConvert, selectedAccount, selectedToken]);
 
   const statusText =
-    veilState === 'waiting'
+    convertState === 'waiting'
       ? 'Waiting for funds to arrive...'
-      : veilState === 'veiling'
-        ? 'Veiling...'
-        : 'Veiled!';
+      : convertState === 'converting'
+        ? 'Converting to confidential APT...'
+        : 'Converted!';
 
   return (
     <div className='flex w-full flex-col gap-3'>
       <p className='typography-body2 text-textSecondary'>
-        Send funds to this address to deposit. They will be veiled automatically once
-        they arrive.
+        Send funds to this address to deposit. They will be converted to confidential APT
+        automatically once they arrive.
       </p>
       {username && <CopyRow label='Username' value={username} />}
       <CopyRow label='Address' value={address} />
@@ -163,12 +163,12 @@ export default function DepositAddress() {
         View on Explorer ({abbrCenter(address)})
       </Link>
       <div className='flex items-center justify-center gap-2 text-sm text-textSecondary'>
-        {veilState === 'veiled' ? (
+        {convertState === 'converted' ? (
           <CheckIcon size={14} className='text-successMain' />
         ) : (
           <RefreshCw size={14} className='animate-spin' />
         )}
-        <span className={veilState === 'veiled' ? 'text-successMain' : ''}>
+        <span className={convertState === 'converted' ? 'text-successMain' : ''}>
           {statusText}
         </span>
       </div>

--- a/src/app/dashboard/components/Deposit/components/DepositMint.tsx
+++ b/src/app/dashboard/components/Deposit/components/DepositMint.tsx
@@ -18,7 +18,7 @@ import { UiSkeleton } from '@/ui/UiSkeleton';
 
 const MINT_AMOUNT = 5;
 
-type FaucetState = 'idle' | 'waiting' | 'veiling' | 'veiled';
+type FaucetState = 'idle' | 'waiting' | 'converting' | 'converted';
 
 export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
   const {
@@ -49,12 +49,12 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
     };
   }, []);
 
-  // Auto-veil function for when funds arrive.
-  const doVeil = useCallback(
+  // Auto-convert function for when funds arrive.
+  const doConvert = useCallback(
     async (amountToDeposit: bigint) => {
       if (!selectedToken || !selectedAccount) return;
 
-      setFaucetState('veiling');
+      setFaucetState('converting');
 
       // Check if this is a coin-based asset (like APT) for choosing the deposit function.
       const [coin] = await tryCatch(getCoinByFaAddress(selectedToken.address));
@@ -90,11 +90,11 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
         ).toFixed(2);
         bus.emit(
           BusEvents.Success,
-          `Successfully veiled full public balance of ${formattedAmount} ${selectedToken.symbol}`,
+          `Successfully converted ${formattedAmount} ${selectedToken.symbol} to confidential APT`,
         );
-        setFaucetState('veiled');
+        setFaucetState('converted');
         setDidSubmit(true);
-        // Don't call onSubmit here - let the user see "Veiled!" before drawer closes.
+        // Don't call onSubmit here - let the user see "Converted!" before drawer closes.
         break;
       } while (depositAttempts < 5);
     },
@@ -128,15 +128,15 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
 
       const initialBal = initialBalanceRef.current ?? 0n;
       if (currentBalance > initialBal) {
-        // Funds arrived! Stop polling and veil.
+        // Funds arrived! Stop polling and convert to confidential APT.
         if (pollingRef.current) {
           clearInterval(pollingRef.current);
           pollingRef.current = null;
         }
-        await doVeil(currentBalance);
+        await doConvert(currentBalance);
       }
     }, 400);
-  }, [doVeil, selectedAccount, selectedToken]);
+  }, [doConvert, selectedAccount, selectedToken]);
 
   // If we're in an active faucet state, skip the currTokenStatus checks and render the faucet UI.
   // This prevents flickering to other states during balance reloads.
@@ -166,7 +166,7 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
     }
   }
 
-  // For assets with external faucets (e.g. APT), show faucet link with auto-veil.
+  // For assets with external faucets (e.g. APT), show faucet link with auto-convert.
   if (assetConfig.faucetUrl) {
     const faucetUrl = getExternalFaucetUrl(selectedAccount.accountAddress.toString());
 
@@ -181,10 +181,10 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
       switch (faucetState) {
         case 'waiting':
           return 'Waiting for funds to arrive...';
-        case 'veiling':
-          return 'Veiling...';
-        case 'veiled':
-          return 'Veiled!';
+        case 'converting':
+          return 'Converting to confidential APT...';
+        case 'converted':
+          return 'Converted!';
         default:
           return null;
       }
@@ -204,12 +204,12 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
         </UiButton>
         {statusText && (
           <div className='flex items-center justify-center gap-2 text-sm text-gray-500'>
-            {faucetState === 'waiting' || faucetState === 'veiling' ? (
+            {faucetState === 'waiting' || faucetState === 'converting' ? (
               <RefreshCw size={14} className='animate-spin' />
-            ) : faucetState === 'veiled' ? (
+            ) : faucetState === 'converted' ? (
               <Check size={14} className='text-green-500' />
             ) : null}
-            <span className={faucetState === 'veiled' ? 'text-green-500' : ''}>
+            <span className={faucetState === 'converted' ? 'text-green-500' : ''}>
               {statusText}
             </span>
           </div>
@@ -247,7 +247,7 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
       break;
     } while (mintAttempts < 5);
 
-    // Now we try to veil the funds.
+    // Now we try to convert the funds to confidential APT.
     let depositAttempts = 0;
 
     do {
@@ -298,7 +298,7 @@ export default function DepositMint({ onSubmit }: { onSubmit?: () => void }) {
       }
       bus.emit(
         BusEvents.Success,
-        `Successfully funded your balance with ${MINT_AMOUNT} ${selectedToken.symbol} and veiled it`,
+        `Successfully funded your balance with ${MINT_AMOUNT} ${selectedToken.symbol} and converted it to confidential APT`,
       );
       setIsSubmitting(false);
       onSubmit?.();

--- a/src/app/dashboard/components/TransferFormSheet.tsx
+++ b/src/app/dashboard/components/TransferFormSheet.tsx
@@ -178,7 +178,7 @@ export const TransferFormSheet = forwardRef<TransferFormSheetRef, Props>(
             })
             .test(
               'hasEncryptionKey',
-              "Recipient can't receive confidential transfers until they veil some APT at least once.",
+              "Recipient can't receive confidential transfers until they convert to confidential APT at least once.",
               async () => {
                 if (!resolvedAddress) return true;
 

--- a/src/app/dashboard/context.tsx
+++ b/src/app/dashboard/context.tsx
@@ -1076,10 +1076,10 @@ export const ConfidentialCoinContextProvider = ({ children }: PropsWithChildren)
   }, 5_000);
   */
 
-  const isAutoVeilingRef = useRef(false);
+  const isAutoConvertingRef = useRef(false);
   useEffect(() => {
-    const autoVeilPublicBalance = async () => {
-      if (isAutoVeilingRef.current) return;
+    const autoConvertPublicBalance = async () => {
+      if (isAutoConvertingRef.current) return;
 
       const currTokenStatus = perTokenStatuses[selectedToken.address];
       if (!currTokenStatus) return;
@@ -1089,7 +1089,7 @@ export const ConfidentialCoinContextProvider = ({ children }: PropsWithChildren)
 
       if (publicBalance <= 0n && pendingBalance <= 0n) return;
 
-      isAutoVeilingRef.current = true;
+      isAutoConvertingRef.current = true;
       try {
         if (publicBalance > 0n) {
           await depositTo(publicBalance, selectedAccount.accountAddress.toString());
@@ -1097,13 +1097,13 @@ export const ConfidentialCoinContextProvider = ({ children }: PropsWithChildren)
         await rolloverAccount();
         await loadSelectedDecryptionKeyState();
       } catch (error) {
-        console.error('Error auto-veiling balance:', error);
+        console.error('Error auto-converting to confidential APT:', error);
       } finally {
-        isAutoVeilingRef.current = false;
+        isAutoConvertingRef.current = false;
       }
     };
 
-    const intervalId = setInterval(autoVeilPublicBalance, 5_000);
+    const intervalId = setInterval(autoConvertPublicBalance, 5_000);
     return () => clearInterval(intervalId);
   }, [
     perTokenStatuses,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Per legal's recommendation, this PR replaces all user-facing references to "veil" / "veiling" / "veiled" with "convert to confidential APT" / "converting" / "converted" across the confidential payments website.

## Changes

**`src/app/dashboard/components/Deposit/components/DepositAddress.tsx`**
- Renamed `VeilState` type → `ConvertState` (with values `'converting'` / `'converted'`)
- Renamed `veilState` / `setVeilState` / `doVeil` → `convertState` / `setConvertState` / `doConvert`
- Updated UI text: "Veiling..." → "Converting to confidential APT...", "Veiled!" → "Converted!"
- Updated description: "They will be veiled automatically" → "They will be converted to confidential APT automatically"
- Updated toast: "Successfully veiled deposit of..." → "Successfully converted ... to confidential APT"

**`src/app/dashboard/components/Deposit/components/DepositMint.tsx`**
- Updated `FaucetState` enum values: `'veiling'` → `'converting'`, `'veiled'` → `'converted'`
- Renamed `doVeil` → `doConvert`
- Updated all UI text and toast messages similarly
- Updated comments referencing "veil" / "auto-veil"

**`src/app/dashboard/components/TransferFormSheet.tsx`**
- Updated validation error: "until they veil some APT at least once" → "until they convert to confidential APT at least once"

**`src/app/dashboard/context.tsx`**
- Renamed `isAutoVeilingRef` → `isAutoConvertingRef`
- Renamed `autoVeilPublicBalance` → `autoConvertPublicBalance`
- Updated error log message

## Notes

- The `.env.example` values (`NEXT_PUBLIC_MAINNET_ANS_DOMAIN=veiled`, `NEXT_PUBLIC_TESTNET_ANS_DOMAIN=veiled`) are actual on-chain ANS domain names and were intentionally left unchanged.
- No occurrences of "unveil" existed in the codebase.
- TypeScript compilation passes cleanly with these changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C03L44G227N/p1782136025879729?thread_ts=1782136025.879729&cid=C03L44G227N)

<div><a href="https://cursor.com/agents/bc-c8644fec-8d81-51a1-8027-57ccda5d49c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8644fec-8d81-51a1-8027-57ccda5d49c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

